### PR TITLE
카테고리 sidebar에 기능 추가

### DIFF
--- a/src/main/java/com/dita/metapilot/category/controller/CategoryController.java
+++ b/src/main/java/com/dita/metapilot/category/controller/CategoryController.java
@@ -233,5 +233,10 @@ public class CategoryController {
     public ResponseEntity<?> getCategoryInfo(@Valid CategoryDto categoryDto) {
         return ResponseEntity.ok(categoryService.getCategoryInfo(categoryDto.getId()));
     }
-    //이 주석은 보이는 대로 지우세요.
+
+    @ResponseBody
+    @GetMapping("/count")
+    public ResponseEntity<?> categoryPostCount() {
+        return ResponseEntity.ok(categoryService.categoryPostCount());
+    }
 }

--- a/src/main/java/com/dita/metapilot/category/entity/CategoryCountEntity.java
+++ b/src/main/java/com/dita/metapilot/category/entity/CategoryCountEntity.java
@@ -1,0 +1,26 @@
+package com.dita.metapilot.category.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryCountEntity {
+    private int id;
+    private int refId;
+    private String subject;
+    private int depth;
+    private int pos;
+    private int type;
+    private int fold;
+    private int visible;
+    private int countVisible;
+    private int listVisible;
+    private int listCount;
+    private String createdAt;
+    private int allCount;
+    private int refCount;
+    private int count;
+}

--- a/src/main/java/com/dita/metapilot/category/repository/CategoryRepository.java
+++ b/src/main/java/com/dita/metapilot/category/repository/CategoryRepository.java
@@ -2,6 +2,7 @@ package com.dita.metapilot.category.repository;
 
 import com.dita.metapilot.category.dto.CategoryDto;
 import com.dita.metapilot.category.dto.CategoryPostDto;
+import com.dita.metapilot.category.entity.CategoryCountEntity;
 import com.dita.metapilot.category.entity.CategoryEntity;
 import com.dita.metapilot.category.entity.CategoryPostEntity;
 import org.apache.ibatis.annotations.Mapper;
@@ -111,5 +112,8 @@ public interface CategoryRepository {
     List<CategoryEntity> categoryHeader();
 
     CategoryEntity getCategoryInfo(int id);
+
+
+    List<CategoryCountEntity> categoryPostCount();
 
 }

--- a/src/main/java/com/dita/metapilot/category/service/CategoryService.java
+++ b/src/main/java/com/dita/metapilot/category/service/CategoryService.java
@@ -2,6 +2,7 @@ package com.dita.metapilot.category.service;
 
 import com.dita.metapilot.category.dto.CategoryDto;
 import com.dita.metapilot.category.dto.CategoryPostDto;
+import com.dita.metapilot.category.entity.CategoryCountEntity;
 import com.dita.metapilot.category.entity.CategoryEntity;
 import com.dita.metapilot.category.entity.CategoryPostEntity;
 import com.dita.metapilot.category.repository.CategoryRepository;
@@ -146,8 +147,23 @@ public class CategoryService {
      * @since 2023. 12. 04.
      * @return 카테고리의 헤더를 List에 담습니다.
      */
+    public List<CategoryCountEntity> categoryPostCount() {
+        return categoryRepository.categoryPostCount();
+    }
+
+
+
+
+    /**
+     * <p>카테고리의 헤더를 List하는 기능</p>
+     * @since 2023. 12. 04.
+     * @return 카테고리의 헤더를 List에 담습니다.
+     */
     public List<CategoryEntity> categoryHeader() {
         return categoryRepository.categoryHeader();
     }
+
+
+
 
 }

--- a/src/main/resources/mappers/category/category.xml
+++ b/src/main/resources/mappers/category/category.xml
@@ -30,6 +30,24 @@
         <result property="createdAt" column="created_at"></result>
     </resultMap>
 
+    <resultMap id="categoryCountEntity" type="com.dita.metapilot.category.entity.CategoryCountEntity">
+        <result property="id" column="id"></result>
+        <result property="refId" column="category_tbl_ref_id"></result>
+        <result property="subject" column="subject"></result>
+        <result property="depth" column="depth"></result>
+        <result property="pos" column="pos"></result>
+        <result property="type" column="type"></result>
+        <result property="fold" column="fold"></result>
+        <result property="visible" column="visible"></result>
+        <result property="countVisible" column="count_visible"></result>
+        <result property="listVisible" column="list_visible"></result>
+        <result property="listCount" column="list_count"></result>
+        <result property="createdAt" column="created_at"></result>
+        <result property="allCount" column="allCount"></result>
+        <result property="refCount" column="refCount"></result>
+        <result property="count" column="count"></result>
+    </resultMap>
+
 
 
     <select id="getCategoryInfo" parameterType="int" resultMap="categoryEntity">
@@ -237,6 +255,20 @@
             where `type` & 8 > 0
             order by pos asc
         ]]>
+    </select>
+
+    <!-- 카테고리에 속한 게시글 수 list -->
+    <select id="categoryPostCount" resultMap="categoryCountEntity">
+        select
+            ct.id, ct.category_tbl_ref_id, ct.subject, ct.depth, ct.pos, ct.type
+            , ct.visible, ct.fold, ct.count_visible, ct.list_visible, ct.list_count
+            , (select count(*) from category_tbl c join post_tbl pt on c.id = pt.category_tbl_id where pt.deleted != 1) as 'allCount'
+            , (select count(*) from category_tbl c join post_tbl pt on c.id = pt.category_tbl_id where pt.deleted != 1 and (c.id = ct.id or c.category_tbl_ref_id = ct.id)) as 'refCount'
+            , (select count(*) from category_tbl c join post_tbl pt on c.id = pt.category_tbl_id where pt.deleted != 1 and c.id = ct.id) as 'count'
+        from
+            category_tbl ct
+        order by
+            ct.pos asc;
     </select>
 
 </mapper>

--- a/src/main/resources/static/layout/home/sidebar.jsx
+++ b/src/main/resources/static/layout/home/sidebar.jsx
@@ -9,7 +9,6 @@ import { color } from "framer-motion"
 import { faDisplay } from "@fortawesome/free-solid-svg-icons"
 import IndexHeader from "./header"
 import PostList from "../../components/common/list"
-/* edd */
 
 /**
  * Rendering the category page.
@@ -94,16 +93,9 @@ const SideBarPage = () => {
 
           axios({
             method: "get",
-            url: "/api/admin/category/list",
+            url: "/api/category/count",
         }).then((res) => {
             setData(res.data);
-
-            const sum = res.data.reduce((accumulator, currentMapper) => {
-              return accumulator + currentMapper.postCount;
-            }, 0);
-
-            setTotalPostCount(sum);
-
             console.log("edd", res.data);
         });
       }, [requestTime]);
@@ -123,16 +115,19 @@ const SideBarPage = () => {
                             {data?.map((mapper) => {
                                 return (
                                     <button key={mapper.id} type="button" style={{fontWeight: mapper.id === 1 ? "bold" : "normal"
-                                    , backgroundColor: mapper.id === categoryId ? "#ECECEC" : "white"}}
+                                    , backgroundColor: mapper.id === categoryId ? "#ECECEC" : "white"
+                                    , display: mapper.visible === 0 ? 'none' : 'block'}}
+                                    /* ↑↑↑↑↑ category의 visible 컬럼이 0(비공개 카테고리)이면 표시하지 않습니다 */
                                     className={`list-group-item list-group-item-action`}
                                     onClick={() => categoryClick(mapper)} >
                                         {
-                                            mapper.depth === 0
+                                            (mapper.depth === 0
                                             ? mapper.subject + 
                                             (mapper.type === 0 || mapper.countVisible === 0 ? ''
-                                                : (mapper.id === 1 ? ' (' + totalPostCount + ')' : ' (' + mapper.totalCount + ')'))
+                                                : (mapper.id === 1 ? ' (' + mapper.allCount + ')' : ' (' + mapper.refCount + ')'))
                                             : ' ㄴ' + mapper.subject +
-                                            (mapper.type === 0 || mapper.countVisible === 0 ? '' : ' (' + mapper.postCount + ')')
+                                            (mapper.type === 0 || mapper.countVisible === 0 ? '' : ' (' + mapper.count + ')'))
+                                            + ' mapper.fold = ' + mapper.fold /* ←----------< 만약 이 값이 0이면 자식 카테고리 접어서 안 보이게 해주세요*/
                                         }
                                     </button>
                                 )


### PR DESCRIPTION
새로운 쿼리문을 사용함으로써
카테고리 sidebar의 기능을 개선했습니다.


category.xml에서 id="categoryCountEntity"를 추가하였는데,
여기서 allCount, refCount, count 이 3개의 컬럼은 각각

 allCount : 전체 카테고리의 게시글 개수 (단, 임시 삭제 된 deleted = 1인 놈들은 제외시켰습니다)

 refCount : 부모 카테고리일 경우, 자기 자신뿐만 아니라 자식들의 모든 게시글 수를 합산하였습니다.

 count : 자식 카테고리일 경우, 그냥 자기 자신의 게시글수만 표시하도록 해놓았습니다.


기존의 sidebar.jsx에서는 admin의 카테고리 수정 기능을 임시로 사용하였지만, 이를 위에서 새로 만든 get방식의 "/api/category/count"로 대처하여 보다 정확하게 DB값을 넘겨주도록 하였습니다.